### PR TITLE
삭제된 프로젝트 배포 정리 작업

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-monorepo-dist-
 
+      - name: Ensure dist directory exists
+        if: steps.changed-apps.outputs.has_changes == 'true'
+        run: mkdir -p dist
+
+      - name: Remove deleted apps from dist
+        if: steps.changed-apps.outputs.has_changes == 'true' && steps.changed-apps.outputs.deleted_apps != '[]'
+        env:
+          DELETED_APPS: ${{ steps.changed-apps.outputs.deleted_apps }}
+        run: node ./scripts/cleanup-deleted-apps.mjs
+
       - name: Build changed apps
         if: steps.changed-apps.outputs.has_changes == 'true'
         env:

--- a/scripts/cleanup-deleted-apps.mjs
+++ b/scripts/cleanup-deleted-apps.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { existsSync, rmSync } from 'node:fs';
+import path from 'node:path';
+
+const raw = process.env.DELETED_APPS || '[]';
+let deletedDirs = [];
+
+try {
+  deletedDirs = JSON.parse(raw);
+} catch (error) {
+  console.warn('Failed to parse DELETED_APPS, skipping cleanup.');
+  process.exit(0);
+}
+
+if (!Array.isArray(deletedDirs) || deletedDirs.length === 0) {
+  console.log('No deleted apps to clean.');
+  process.exit(0);
+}
+
+deletedDirs
+  .map(String)
+  .sort()
+  .forEach(dir => {
+    const target = path.join('dist', dir);
+    if (existsSync(target)) {
+      rmSync(target, { recursive: true, force: true });
+      console.log(`Removed ${target}`);
+    } else {
+      console.log(`Skip removal, ${target} not found.`);
+    }
+  });


### PR DESCRIPTION
## #️⃣ 이 작업의 연관 이슈
- resolved #11 

## 작업 내용
<!-- 변경사항과 구현 로직에 대한 설명 -->
- apps 폴더를 순회한 후 프로젝트 목록 저장 
- 이전에 배포했던 GitHub Pagse 아티팩트 내역(=캐시된 파일들)에 삭제한 프로젝트가 존재하면 제거

## Breaking Change 포함 여부
- [ ] 네 (Reviewer에 개발자를 추가하고 변경 내용을 팀에 전파해 주세요.)
- [x] 아니오
 